### PR TITLE
Fix systemd script to include correct JENKINS_JAVA_OPTIONS

### DIFF
--- a/files/usr/lib/systemd/system/jenkins.service
+++ b/files/usr/lib/systemd/system/jenkins.service
@@ -5,7 +5,7 @@ Before=httpd.service
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/jenkins
-ExecStart=/usr/bin/java -Djenkins.install.runSetupWizard=false -Dcom.sun.akuma.Daemon=daemonized ${JENKINS_JAVA_OPTIONS} -DJENKINS_HOME=${JENKINS_HOME} -jar /usr/lib/jenkins/jenkins.war --logfile=/var/log/jenkins/jenkins.log --webroot=/var/cache/jenkins/war --daemon --httpPort=${JENKINS_PORT} --debug=${JENKINS_DEBUG_LEVEL} --handlerCountMax=${JENKINS_HANDLER_MAX} --handlerCountMaxIdle=${JENKINS_HANDLER_IDLE}
+ExecStart=/usr/bin/java $JENKINS_JAVA_OPTIONS -Djenkins.install.runSetupWizard=false -Dcom.sun.akuma.Daemon=daemonized -DJENKINS_HOME=$JENKINS_HOME -jar /usr/lib/jenkins/jenkins.war --logfile=/var/log/jenkins/jenkins.log --webroot=/var/cache/jenkins/war --daemon --httpPort=$JENKINS_PORT --debug=$JENKINS_DEBUG_LEVEL --handlerCountMax=$JENKINS_HANDLER_MAX --handlerCountMaxIdle=$JENKINS_HANDLER_IDLE
 User=jenkins
 Restart=no
 StandardOutput=null


### PR DESCRIPTION
> Similar to Environment= but reads the environment variables from a text file. The text file should contain new-line-separated variable assignments. Empty lines, lines without an "=" separator, or lines starting with ; or # will be ignored, which may be used for commenting. A line ending with a backslash will be concatenated with the following one, allowing multiline variable definitions. The parser strips leading and trailing whitespace from the values of assignments, unless you use double quotes (").

> The argument passed should be an absolute filename or wildcard expression, optionally prefixed with "-", which indicates that if the file does not exist, it will not be read and no error or warning message is logged. This option may be specified more than once in which case all specified files are read. If the empty string is assigned to this option, the list of file to read is reset, all prior assignments have no effect.

> The files listed with this directive will be read shortly before the process is executed (more specifically, after all processes from a previous unit state terminated. This means you can generate these files in one unit state, and read it with this option in the next).

> Settings from these files override settings made with Environment=. If the same variable is set twice from these files, the files will be read in the order they are specified and the later setting will override the earlier setting.

All the arguments in `$JENKINS_JAVA_OPTIONS` were passed as one long argument. No surprise that it didn't work.

In fact, the service file is correct. Its configuration just can't be made compatible with bash, because it is in a different language. The service works with the following configuration file (alas, incompatible with bash):
`JENKINS_JAVA_OPTIONS=-Djava.awt.headless=true -Xms1024m -Xmx4096m`

reference [blogpost](http://patrakov.blogspot.be/2011/01/writing-systemd-service-files.html)