### PR TITLE
ReFix systemd script to include correct JENKINS_JAVA_OPTIONS

### DIFF
--- a/files/usr/lib/systemd/system/jenkins.service
+++ b/files/usr/lib/systemd/system/jenkins.service
@@ -5,7 +5,7 @@ Before=httpd.service
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/jenkins
-ExecStart=/usr/bin/java $JENKINS_JAVA_OPTIONS -Djenkins.install.runSetupWizard=false -Dcom.sun.akuma.Daemon=daemonized -DJENKINS_HOME=$JENKINS_HOME -jar /usr/lib/jenkins/jenkins.war --logfile=/var/log/jenkins/jenkins.log --webroot=/var/cache/jenkins/war --daemon --httpPort=$JENKINS_PORT --debug=$JENKINS_DEBUG_LEVEL --handlerCountMax=$JENKINS_HANDLER_MAX --handlerCountMaxIdle=$JENKINS_HANDLER_IDLE
+ExecStart=/usr/bin/java $JENKINS_JAVA_OPTIONS -Djenkins.install.runSetupWizard=false -Dcom.sun.akuma.Daemon=daemonized -DJENKINS_HOME=${JENKINS_HOME} -jar /usr/lib/jenkins/jenkins.war --logfile=/var/log/jenkins/jenkins.log --webroot=/var/cache/jenkins/war --daemon --httpPort=${JENKINS_PORT} --debug=${JENKINS_DEBUG_LEVEL} --handlerCountMax=${JENKINS_HANDLER_MAX} --handlerCountMaxIdle=${JENKINS_HANDLER_IDLE}
 User=jenkins
 Restart=no
 StandardOutput=null


### PR DESCRIPTION
Changes in pull-request https://github.com/cegeka/puppet-jenkins/pull/10 resulted in a Jenkins startup failure.
Seems only the $JENKINS_JAVA_OPTIONS parameter must not be enclosed in curly brackets.
Other variables in this config are variable assignments, where curly brackets must be used.

I dont' know why this is required.
Tests showed that this config works. $JENKINS_JAVA_OPTIONS is read correctly as are all other variables.